### PR TITLE
rt44 replies with 'Correspondence added' body, so roust should'nt throw

### DIFF
--- a/lib/roust/ticket.rb
+++ b/lib/roust/ticket.rb
@@ -100,7 +100,7 @@ class Roust
         body, _ = explode_response(response)
 
         case body
-        when /^# (Message recorded|Comments added)/
+        when /^# (Message recorded|Comments added|Correspondence added)/
           ticket_show(id)
         when /^# You are not allowed to modify ticket \d+/
           raise Unauthorized, body


### PR DESCRIPTION
When using roust on a current rt (version 4.4), I noticed adding correspondence leading to an exception, because correspondence is reported as successfully commented, anymore.

This patch adds 'Correspondence added' to the acceptable responses.