### PR TITLE
Fix: If ticket/1 is inaccessible, roust would throw in authenticated

### DIFF
--- a/lib/roust.rb
+++ b/lib/roust.rb
@@ -45,7 +45,7 @@ class Roust
 
     cookie = response.headers['set-cookie']
     self.class.default_cookies.add_cookies(cookie) if cookie
-    self.class.headers(:referer => "#{@server}/REST/1.0")
+    self.class.headers('Referer' => "#{@server}/REST/1.0")
 
     # Switch the base uri over to the actual REST API base uri.
     self.class.base_uri "#{@server}/REST/1.0"

--- a/lib/roust.rb
+++ b/lib/roust.rb
@@ -60,7 +60,8 @@ class Roust
   end
 
   def authenticated?
-    return true if show('1')
+    show('1')
+    return true
   rescue Unauthenticated
     return false
   end

--- a/lib/roust.rb
+++ b/lib/roust.rb
@@ -44,7 +44,8 @@ class Roust
     )
 
     cookie = response.headers['set-cookie']
-    self.class.headers['Cookie'] = cookie if cookie
+    self.class.default_cookies.add_cookies(cookie) if cookie
+    self.class.headers(:referer => "#{@server}/REST/1.0")
 
     # Switch the base uri over to the actual REST API base uri.
     self.class.base_uri "#{@server}/REST/1.0"

--- a/lib/roust/ticket.rb
+++ b/lib/roust/ticket.rb
@@ -6,6 +6,7 @@ class Roust
       body, _ = explode_response(response)
 
       return nil if body =~ /^# (Ticket (\d+) does not exist\.)/
+      return nil if body =~ /^# You are not allowed to display ticket (\d+)./
 
       parse_ticket_attributes(body)
     end


### PR DESCRIPTION
The function `authenticated?` in roust.rb would check for an `Unauthenticated` exception thrown from the function `show('1')`.

However, if an http request to `ticket/1` returns a `# You are not allowed to display ticket 1.`, `ticket_show('1')` would continue to call `parse_ticket_attributes` which happily tries to expand the response body, creates a `hash = body_to_hash(body)` assuming that an `id = ticket/1` field is present in the response body.

Once it tries to access its 'id' key in `hash['id'] = hash['id'].split('/').last`, it throws  `undefined method `split' for nil:NilClass`.

Additionally, if the ticket/1 is not present at all, `authenticated?` would untruthfully not return true, because the `if show('1')` test fails.

This patch prevents `ticket_show()` to continue if the ticket is disallowed and properly returns true in `authenticate?`, if no exception is thrown.
